### PR TITLE
fixed tostring()/tobytes() numpy warning

### DIFF
--- a/src/pydap/lib.py
+++ b/src/pydap/lib.py
@@ -282,7 +282,7 @@ def get_var(dataset, id_):
 def decode_np_strings(numpy_var):
     """Given a fixed-width numpy string, decode it to a unicode type"""
     if isinstance(numpy_var, binary_type) and hasattr(numpy_var, 'tostring'):
-        return numpy_var.tostring().decode('utf-8')
+        return numpy_var.tobytes().decode('utf-8')
     else:
         return numpy_var
 

--- a/src/pydap/responses/dods.py
+++ b/src/pydap/responses/dods.py
@@ -45,7 +45,7 @@ def tostring_with_byteorder(x, dtype):
     return (x
             .astype(dtype.str)
             .newbyteorder(dtype.byteorder)
-            .tostring())
+            .tobytes())
 
 
 class DODSResponse(BaseResponse):
@@ -140,7 +140,7 @@ def _sequencetype(var):
             # occurs naturally:
             cache[DAP2_dtype_str][:] = tuple(record)
             # byteorder was taken care of during the upconversion:
-            yield cache[DAP2_dtype_str].tostring()
+            yield cache[DAP2_dtype_str].tobytes()
 
         yield END_OF_SEQUENCE
 
@@ -215,7 +215,7 @@ def _basetype(var):
                     if hasattr(word, 'encode'):
                         yield word.encode('ascii')
                     elif hasattr(word, 'tostring'):
-                        yield word.tostring()
+                        yield word.tobytes()
                     else:
                         raise TypeError("Could not convert word '{0}' to bytes"
                                         .format(word))

--- a/src/pydap/tests/test_responses_dods.py
+++ b/src/pydap/tests/test_responses_dods.py
@@ -181,28 +181,28 @@ class TestDODSResponseStructure(unittest.TestCase):
             # -10 signed byte upconv. to Int32 for transfer
             ('b', (np.array(-10, dtype=np.byte)
                    .astype('>i')
-                   .tostring())),
+                   .tobytes())),
             # 10 usigned byte padded to multiple of 4 bytes for transfer
             ('ub', (np.array(10, dtype=np.ubyte)
-                    .tostring()) + b'\x00\x00\x00'),
+                    .tobytes()) + b'\x00\x00\x00'),
             ('i32', (np.array(-10, dtype=np.int32)
-                     .astype('>i').tostring())),
+                     .astype('>i').tobytes())),
             ('ui32', (np.array(10, dtype=np.uint32)
-                      .astype('>I').tostring())),
+                      .astype('>I').tobytes())),
             # -10 int16 upconv. to int32 for transfer
             ('i16', (np.array(-10, dtype=np.int16)
                      .astype('>i')
-                     .newbyteorder('>').tostring())),
+                     .newbyteorder('>').tobytes())),
             # 10 uint16 upconv. to uint32 for transfer
             ('ui16', (np.array(10, dtype=np.uint16)
                       .astype('>I')
-                      .tostring())),
+                      .tobytes())),
             ('f32', (np.array(100, dtype=np.float32)
                      .astype('>f')
-                     .tostring())),
+                     .tobytes())),
             ('f64', (np.array(1000, dtype=np.float64)
                      .astype('>d')
-                     .tostring())),
+                     .tobytes())),
             ('s', b'\x00\x00\x00$This is a data test string (pass 0).\x00'),
             ('u', b'\x00\x00\x13http://www.dods.org\x00'),
             ('U', b'\x00\x00\x00\x0ctest unicode')])

--- a/src/pydap/tests/test_responses_error.py
+++ b/src/pydap/tests/test_responses_error.py
@@ -34,7 +34,7 @@ class TestErrorResponse(unittest.TestCase):
                          'pydap/' + __version__)
 
     def test_body(self):
-        self.assertRegexpMatches(self.res.text, r"""Error {
+        self.assertRegex(self.res.text, r"""Error {
     code = -1;
     message = "Traceback \(most recent call last\):
   File .*


### PR DESCRIPTION
fixed tostring()/tobytes() numpy warning